### PR TITLE
[BUGFIX] Use correct ext_emconf configuration

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF['rte_ckeditor_pack'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'CKEditor Pack',
     'description' => 'CKEditor Pack TYPO3 extension provides a modern, integrated CKEditor build many optimized features, accessibility tools, AI assistance, and collaboration-friendly options—all without managing scattered YAML files. Built for stability and clean integration, it streamlines editing workflows and enhances TYPO3 content quality.',
     'category' => 'be',


### PR DESCRIPTION
The variable `$_EXTKEX` must not be set, as this is important for non-composer based installations